### PR TITLE
docs(libsodium): add missing dependency to libsodium for build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ deps = [
     dependency('libnotify'),
     dependency('libtoxcore'),
     dependency('libconfig'),
+    dependency('libsodium')
 ]
 
 


### PR DESCRIPTION
Hello! I had compilations errors due to libsodium not being installed on my system. I realized that it wasn't specified in the `meson.build` file, so I've added it, and now compilation works fine.
