### PR TITLE
fix(travis): change GTK+3.18 PPA, fix #44

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
  - sudo apt-add-repository ppa:vala-team/ppa -y
  - sudo apt-add-repository ppa:mc3man/trusty-media -y
 
-# Travis requires gtk+ 3.18 to compile.
- - sudo apt-add-repository ppa:ubuntu-desktop/ppa -y
+# Travis requires gtk+ 3.16 to compile.
+ - sudo add-apt-repository ppa:rebuntu16/glade-3.19+-trusty -y
 
  - sudo apt-get update -q
  - sudo apt-get install -y checkinstall build-essential texinfo libgtk-3-dev libglib2.0-dev libgdk-pixbuf2.0-dev libsoup2.4-dev libjson-glib-dev libnotify-bin python3 valac-0.30 libnotify-dev libopus-dev ffmpeg
@@ -66,7 +66,6 @@ before_script:
  - cd ..
 
 script:
- - cd /home/travis/build/RicinApp/Ricin
  - make autogen
  - make install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 
 script:
  - make autogen
- - make install
+ - sudo make install
 
 notifications:
   email: false


### PR DESCRIPTION
ubuntu-desktop/ppa doesn't provide GTK 3.18 for trusty
(see: https://launchpad.net/~ubuntu-desktop/+archive/ubuntu/ppa?field.series_filter=trusty)

I change it to another PPA which provide GTK 3.16.

Now travis can compile Ricin properly, but still build fails at installing stage.
