### PR TITLE
fix(meson): meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
     'Ricin',
     'vala',
     'c', # compiling vala requires a C compiler
-    meson_version: '>0.31.0'
+    meson_version: '>=0.31.0'
 )
 gnome = import('gnome')
 


### PR DESCRIPTION
fix build:

```
Meson encountered an error in file meson.build, line 2, column 0:
Meson version is 0.31.0 but project requires >0.31.0.
Makefile:31: recipe for target 'autogen' failed
make: *** [autogen] Error 1
```
