### PR TITLE
chore(appimage): also bundle libglib-2.0.so.0 and friends

### DIFF
--- a/appimage.sh
+++ b/appimage.sh
@@ -48,6 +48,13 @@ wget https://raw.githubusercontent.com/RicinApp/ricin.im/master/static/images/ap
 # undefined symbol: g_type_check_instance_is_fundamentally_a
 # Function g_type_check_instance_is_fundamentally_a was introduced in glib2-2.41.1
 # Bundle libglib-2.0.so.0 - TODO: find a better solution, e.g., downgrade libglib-2.0 at compile time
+mkdir -p ./usr/lib/
+cp $(ldconfig -p | grep libglib-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+# The following come with glib2 and probably need to be treated together:
+cp $(ldconfig -p | grep libgio-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+cp $(ldconfig -p | grep libgmodule-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+cp $(ldconfig -p | grep libgobject-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+cp $(ldconfig -p | grep libgthread-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
 
 export LD_LIBRARY_PATH=/home/travis/build/RicinApp/Ricin.AppImage/usr/lib/:LD_LIBRARY_PATH
 copy_deps
@@ -64,6 +71,14 @@ rm -r usr/lib/x86_64-linux-gnu/ usr/local/lib/
 # Delete dangerous libraries; see
 # https://github.com/probonopd/AppImages/blob/master/excludelist
 delete_blacklisted
+
+# In this case we need to override the blacklisting, hence doing it again
+cp $(ldconfig -p | grep libglib-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+# The following come with glib2 and probably need to be treated together:
+cp $(ldconfig -p | grep libgio-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+cp $(ldconfig -p | grep libgmodule-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+cp $(ldconfig -p | grep libgobject-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
+cp $(ldconfig -p | grep libgthread-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./usr/lib/
 
 # We don't bundle the developer stuff
 rm -rf usr/include || true


### PR DESCRIPTION
Also bundle libglib-2.0.so.0 and friends to make AppImage compatible with distributions using older glib versions. Closes #127
