### PR TITLE
refactor(file transfers): massive refactoring

### DIFF
--- a/res/ricin.gresource.xml
+++ b/res/ricin.gresource.xml
@@ -4,6 +4,7 @@
         <file preprocess="xml-stripblanks" compressed="true">ui/main-window.ui</file>
         <file preprocess="xml-stripblanks" compressed="true">ui/profile-chooser-window.ui</file>
         <file preprocess="xml-stripblanks" compressed="true">ui/friend-list-row.ui</file>
+        <file preprocess="xml-stripblanks" compressed="true">ui/file-list-row.ui</file>
         <file preprocess="xml-stripblanks" compressed="true">ui/status-message-list-row.ui</file>
         <file preprocess="xml-stripblanks" compressed="true">ui/system-message-list-row.ui</file>
         <file preprocess="xml-stripblanks" compressed="true">ui/inline-image-message-list-row.ui</file>

--- a/res/ui/file-list-row.ui
+++ b/res/ui/file-list-row.ui
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.19.0 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <template class="RicinFileListRow" parent="GtkListBoxRow">
+    <property name="width_request">250</property>
+    <property name="height_request">20</property>
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <property name="resize_mode">queue</property>
+    <property name="activatable">False</property>
+    <property name="selectable">False</property>
+    <child>
+      <object class="GtkEventBox" id="eventbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkLabel" id="label_name">
+                <property name="width_request">80</property>
+                <property name="height_request">20</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
+                <property name="label">label</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+                <property name="width_chars">12</property>
+                <property name="single_line_mode">True</property>
+                <property name="max_width_chars">12</property>
+                <property name="track_visited_links">False</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="box_widget">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">start</property>
+                <child>
+                  <object class="GtkBox" id="box2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkAspectFrame" id="aspectframe_preview">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkImage" id="image_preview">
+                            <property name="can_focus">False</property>
+                            <property name="stock">gtk-missing-image</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="box3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkBox" id="box_background">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">5</property>
+                            <child>
+                              <object class="GtkImage" id="image_file_type">
+                                <property name="name">50</property>
+                                <property name="width_request">30</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="icon_name">text-x-generic-symbolic</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label_file_name">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">2</property>
+                                <property name="margin_bottom">2</property>
+                                <property name="label">file_name.ext</property>
+                                <property name="ellipsize">end</property>
+                                <property name="max_width_chars">30</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkProgressBar" id="progress_file_percent">
+                                <property name="can_focus">False</property>
+                                <property name="valign">center</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label_file_size">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="label">(0 Kb)</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="box4">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkButton" id="button_reject">
+                                <property name="width_request">20</property>
+                                <property name="height_request">20</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="tooltip_text" translatable="yes">Cancel/pause file</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="always_show_image">True</property>
+                                <signal name="clicked" handler="reject_file" swapped="no"/>
+                                <child>
+                                  <object class="GtkImage" id="image_reject_inline">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="pixel_size">16</property>
+                                    <property name="icon_name">window-close-symbolic</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="btn-save-image"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="button_save">
+                                <property name="width_request">20</property>
+                                <property name="height_request">20</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="tooltip_text" translatable="yes">Accept/Resume file</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="always_show_image">True</property>
+                                <signal name="clicked" handler="save_file" swapped="no"/>
+                                <child>
+                                  <object class="GtkImage" id="image_save_inline">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="pixel_size">16</property>
+                                    <property name="icon_name">object-select-symbolic</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="btn-save-image"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <style>
+                          <class name="image-desc"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_timestamp">
+                <property name="width_request">70</property>
+                <property name="height_request">20</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="valign">start</property>
+                <property name="label">00:00.00</property>
+                <property name="justify">right</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+                <property name="single_line_mode">True</property>
+                <attributes>
+                  <attribute name="size" value="9000"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <style>
+      <class name="message"/>
+    </style>
+  </template>
+</interface>

--- a/src/FileListRow.vala
+++ b/src/FileListRow.vala
@@ -1,0 +1,249 @@
+[GtkTemplate (ui="/chat/tox/ricin/ui/file-list-row.ui")]
+class Ricin.FileListRow : Gtk.ListBoxRow {
+  [GtkChild] Gtk.Label label_name;
+  [GtkChild] Gtk.Label label_timestamp;
+
+  [GtkChild] Gtk.Box box_widget;
+  [GtkChild] Gtk.ProgressBar progress_file_percent;
+  [GtkChild] public Gtk.Button button_save;
+  [GtkChild] Gtk.Image image_save_inline;
+  [GtkChild] public Gtk.Button button_reject;
+  [GtkChild] Gtk.Image image_reject_inline;
+
+  [GtkChild] Gtk.Box box_background;
+  [GtkChild] Gtk.Image image_file_type;
+  [GtkChild] Gtk.Label label_file_name;
+  [GtkChild] Gtk.Label label_file_size;
+
+  [GtkChild] Gtk.AspectFrame aspectframe_preview;
+  [GtkChild] Gtk.Image image_preview;
+
+  private File file;
+  private uint32 file_id;
+  private string file_name;
+  private uint64 file_size;
+  private uint64 raw_size;
+  private uint position;
+
+  // Managing the download
+  private bool downloaded = false;
+  private bool paused = false;
+
+  private weak Tox.Tox handle;
+  private weak Tox.Friend sender;
+  private Settings settings;
+
+  public signal void accept_file (bool response, uint32 file_id);
+
+  public FileListRow (Tox.Tox handle, Tox.Friend sender, uint32 file_id, string username, string file_path, uint64 file_size, string timestamp, bool is_local_image = false, Gdk.Pixbuf? pixbuf = null, string? pixbuf_name = null) {
+    this.handle = handle;
+    this.sender = sender;
+    this.settings = Settings.instance;
+
+    this.file = File.new_for_path (file_path);
+    this.file_id = file_id;
+    this.raw_size = file_size;
+
+    if (is_local_image) { // File is a local image.
+      FileInfo info = this.file.query_info ("standard::*", 0);
+      this.file_name = info.get_display_name ();
+      this.file_size = info.get_size ();
+
+      //var pix = new Gdk.Pixbuf.from_file_at_scale (this.file.get_path (), 400, 400, true);
+      var pix = new Gdk.Pixbuf.from_file (this.file.get_path ());
+      this.image_preview.set_from_pixbuf (pix);
+    } else if (pixbuf != null) { // File is an image.
+      this.file_name = pixbuf_name;
+      this.file_size = pixbuf.get_byte_length ();
+
+      var pix = pixbuf.scale_simple (this.aspectframe_preview.width_request, 200, Gdk.InterpType.BILINEAR);
+      this.image_preview.set_from_pixbuf (pixbuf);
+      this.image_preview.visible = true;
+    } else { // Normal file.
+      this.file_name = this.file.get_basename ();
+      this.file_size = file_size;
+    }
+
+    this.label_name.set_markup (@"<b>$username</b>");
+    this.label_timestamp.set_text (timestamp);
+    this.label_file_name.set_text (this.file_name);
+    this.label_file_size.set_text (Util.size_to_string (this.file_size));
+    this.progress_file_percent.set_fraction (0.0);
+
+    // If message is our (ugly&hacky way).
+    if (this.handle.username == username) {
+      debug ("Keeping names in sync !");
+      this.handle.bind_property ("username", label_name, "label", BindingFlags.DEFAULT);
+    }
+
+
+    this.sender.file_done.connect ((name, bytes, id) => {
+      if (id != this.file_id) {
+        return;
+      }
+
+      debug (@"File $(this.file_id) done!");
+
+      // Set the progressbar to 100% and hide it.
+      this.progress_file_percent.set_fraction (1.0);
+      this.progress_file_percent.visible = false;
+
+      string downloads = this.settings.default_save_path;
+      File file_destination = File.new_for_path (@"$downloads/$(this.file_name)");
+      if (FileUtils.test (file_destination.get_path (), FileTest.EXISTS)) {
+        Rand rnd = new Rand.with_seed ((uint32)new DateTime.now_local ().hash ());
+        uint32 rnd_id = rnd.next_int ();
+        string filename = @"$rnd_id-$(this.file_name)";
+        file_destination = File.new_for_path (downloads.concat ("/", filename));
+        FileUtils.set_data (file_destination.get_path (), bytes.get_data ());
+        this.file = file_destination;
+      } else {
+        file_destination = File.new_for_path (downloads.concat ("/", this.file_name));
+        FileUtils.set_data (file_destination.get_path (), bytes.get_data ());
+        this.file = file_destination;
+      }
+
+      this.downloaded = true;
+      this.box_widget.get_style_context().add_class ("saved-file");
+      this.button_save.set_size_request (65, 20);
+      this.button_reject.visible = false;
+      this.image_save_inline.icon_name = "folder-open-symbolic";
+      this.button_save.sensitive = true;
+    });
+
+    this.sender.file_received.connect (id => {
+      if (id != this.file_id) {
+        return;
+      }
+
+      this.downloaded = true;
+      this.progress_file_percent.visible = false;
+      this.box_widget.get_style_context().add_class ("saved-file");
+      this.button_save.set_size_request (65, 20);
+      this.button_reject.visible = false;
+      this.button_save.sensitive = true;
+      //this.label_foreground.width_request = -1;
+      this.image_save_inline.icon_name = "object-select-symbolic";
+      this.button_save.set_tooltip_text ("File saved. Click to open");
+    });
+
+    this.sender.file_progress.connect ((id, position) => {
+      if (id != this.file_id) return;
+
+      var percent = position / this.raw_size;
+      debug (@"File $id - Size: $(this.raw_size) - Position: $position");
+      debug (@"Progress percent: $percent");
+      //debug (@"Received %s% of file %s", percent, id);
+      this.progress_file_percent.set_fraction ((int) percent);
+      this.progress_file_percent.visible = true;
+
+      /*this.progressbar_buffer.notify["fraction"].connect((o, p) => {
+        this.label_foreground.width_request = (int) this.progressbar_buffer.fraction * 100;
+      });*/
+    });
+
+    this.sender.file_paused.connect (id => {
+      if (id != this.file_id) {
+        return;
+      }
+
+      this.image_save_inline.icon_name = "media-playback-start-symbolic";
+    });
+
+    this.sender.file_resumed.connect (id => {
+      if (id != this.file_id) {
+        return;
+      }
+
+      this.image_save_inline.icon_name = "media-playback-pause-symbolic";
+    });
+
+    this.sender.file_canceled.connect (id => {
+      if (id != this.file_id) {
+        return;
+      }
+
+      this.file_id = -1; // File doesn't exists now, avoid issues.
+      this.box_widget.get_style_context().add_class ("canceled-file");
+      this.button_reject.set_size_request (65, 20);
+      this.button_reject.sensitive = false;
+      //this.label_foreground.width_request = -1;
+      this.button_save.visible = false;
+      this.progress_file_percent.visible = false;
+      this.button_reject.set_tooltip_text ("Canceled");
+    });
+
+    /*this.sender.file_progress.connect ((id, position) => {
+      if (id != this.file_id)
+        return;
+
+      debug (@"File Progress: id: $id - position: $position");
+    });*/
+  }
+
+  [GtkCallback]
+  private void save_file () {
+    /**
+    * TODO: Handle multiple state of the button using a less hacky way.
+    **/
+    if (this.downloaded == false) {
+      debug ("Requested to save file");
+      this.accept_file (true, this.file_id);
+      this.progress_file_percent.visible = true;
+      /*this.box_widget.get_style_context().add_class ("progress-bg");
+      this.label_foreground.get_style_context().add_class ("progress-fg");
+      this.progress_transfers.visible = true;*/
+    } else {
+      /**
+      * TODO: Open the file in folder.
+      **/
+      try {
+        AppInfo.launch_default_for_uri (this.file.get_uri (), null);
+      } catch (Error e) {
+        debug (@"Cannot open $(this.file_name): $(e.message)");
+      }
+      return;
+    }
+
+    if (this.paused == false) {
+      this.paused = !this.paused;
+      this.image_save_inline.icon_name = "media-playback-pause-symbolic";
+      //this.label_foreground.width_request = this.label_foreground.width_request + 10;
+    } else {
+      this.paused = !this.paused;
+      this.image_save_inline.icon_name = "media-playback-start-symbolic";
+    }
+
+    /**
+    * TODO: Change box_widget background to progress.
+    * NOTE: Use a Gtk.Overlay and change it's background color + update width
+    *       of the overlay related to the file progress.
+    **/
+    /*this.box_widget.get_style_context().add_class ("saved-file");
+    this.button_save.set_size_request (65, 20);
+    this.button_save.sensitive = false;
+    this.button_reject.visible = false;*/
+  }
+
+  [GtkCallback]
+  private void reject_file () {
+    this.accept_file (false, this.file_id);
+    this.file_id = -1; // File doesn't exists now, avoid issues.
+
+    /**
+    * TODO: Change box_widget background to red.
+    * NOTE: Use the .canceled-file css class defined in default.css
+    **/
+    this.box_widget.get_style_context().add_class ("canceled-file");
+
+    //this.button_reject.label = "Canceled";
+    /*this.progress_transfers.visible = false;*/
+    this.button_reject.set_size_request (65, 20);
+    this.button_reject.sensitive = false;
+    this.button_save.visible = false;
+  }
+
+  private void open_file () {
+
+  }
+}

--- a/src/SettingsView.vala
+++ b/src/SettingsView.vala
@@ -333,7 +333,7 @@ class Ricin.SettingsView : Gtk.Box {
       Gtk.DialogFlags.MODAL,
       Gtk.MessageType.WARNING,
       Gtk.ButtonsType.NONE,
-      title
+      "%s", title
     );
 
     dialog.secondary_use_markup = true;

--- a/src/Wrapper.vala
+++ b/src/Wrapper.vala
@@ -397,6 +397,10 @@ namespace Tox {
           fr.files_recv.remove (file);
           return;
         }
+
+        debug (@"friend $friend, file $file: chunk request, pos=$position");
+        this.friends[friend].file_progress (file, position);
+
         assert (fr.files_recv[file].data.len == position);
         fr.files_recv[file].data.append (data);
       });
@@ -479,7 +483,7 @@ namespace Tox {
         debug ("Done bootstrapping");
       }
     }
-    
+
     public Friend? add_friend (string id, string message) throws ErrFriendAdd {
       if (id.length != ToxCore.ADDRESS_SIZE && id.index_of_char ('@') != -1) {
         error ("Invalid Tox ID");
@@ -836,6 +840,15 @@ namespace Tox {
       var id = this.tox.handle.file_send (this.num, FileKind.DATA, info.get_size (), null, file.get_basename ().data, null);
       uint8[] data;
       FileUtils.get_data (path, out data);
+      this.files_send[id] = new Bytes.take (data);
+
+      return id;
+    }
+
+    public uint32 send_image (Gdk.Pixbuf pixbuf, string name) {
+      uint8[] data;
+      pixbuf.save_to_buffer (out data, "png");
+      var id = this.tox.handle.file_send (this.num, FileKind.DATA, data.length, null, name.data, null);
       this.files_send[id] = new Bytes.take (data);
 
       return id;

--- a/wscript
+++ b/wscript
@@ -40,7 +40,8 @@ def configure(conf):
 		'-Wno-unused-variable',
 		'-Wno-unused-but-set-variable',
 		'-Wno-unused-function',
-		'-DGETTEXT_PACKAGE="ricin"'
+		'-DGETTEXT_PACKAGE="ricin"',
+		'-O3' # Optimizatiooooons!
 	])
 	# Vala compiler flags.
 	conf.env.append_unique('VALAFLAGS', [


### PR DESCRIPTION
In order to accomplish a complete refactoring of the `ChatView` code, I merged both `InlineImageMessageListRow` and `InlineFileMessageListRow` into `FileListRow`, also currently working on having progress bar + inline images working correctly.

This commit also add the ability to paste an image into Ricin to send it:
- Firefox: Right click an image → Copy image.
- Ricin: `ctrl+v` → Image is sent to friend.

**Note:** This PR is WIP, not ready to be merged yet.
