### PR TITLE
 	feat(emojione): add support for EmojiOne font if installed on the system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ autogen:
 	./waf distclean
 	./waf configure
 
-build: autogen
+build:
 	./waf build
 
 debug: build

--- a/src/Ricin.vala
+++ b/src/Ricin.vala
@@ -2,7 +2,7 @@ public class Ricin.Ricin : Gtk.Application {
   const string GETTEXT_PACKAGE = "ricin";
   public static const string APP_NAME = "Ricin";
   public static const string APP_SUMMARY = "<b>Ricin</b> aims to be a <i>secure, lightweight, hackable and fully-customizable</i> chat client using the awesome and open-source <b>ToxCore</b> library.";
-  public static const string APP_VERSION = "0.2.1";
+  public static const string APP_VERSION = "0.2.2";
   public static const string RES_BASE_PATH = "/chat/tox/ricin/";
   public static const string ICON_PATH = RES_BASE_PATH + "images/icons/ricin.svg";
 

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -75,39 +75,6 @@ namespace Util {
     string escaped_text = escape_html (text);
     string emojified = render_emojis (escaped_text);
 
-    /*string emoji = escaped_text
-      .replace (":+1:", Util.emoji ("👍"))
-      .replace (":-1:", Util.emoji ("👎"))
-      .replace (":@", Util.emoji ("😠"))
-      .replace (">:(", Util.emoji ("😠"))
-      .replace (":$", Util.emoji ("😊"))
-      .replace ("<3", Util.emoji ("💙"))
-      .replace (":3", Util.emoji ("🐱"))
-      .replace (":\\", Util.emoji ("😕"))
-      .replace (":'(", Util.emoji ("😢"))
-      .replace (":-'(", Util.emoji ("😢"))
-      .replace (":o", Util.emoji ("😵"))
-      .replace (":O", Util.emoji ("😵"))
-      .replace (":(", Util.emoji ("😦"))
-      .replace (":-(", Util.emoji ("😦"))
-      .replace (":-[", Util.emoji ("😦"))
-      .replace (":[", Util.emoji ("😦"))
-      .replace ("xD", Util.emoji ("😆"))
-      .replace ("XD", Util.emoji ("😆"))
-      .replace ("0:)", Util.emoji ("😇"))
-      .replace (":)", Util.emoji ("😄"))
-      .replace (":D", Util.emoji ("😁"))
-      .replace (":-D", Util.emoji ("😁"))
-      .replace (":|", Util.emoji ("😐"))
-      .replace (":-|", Util.emoji ("😐"))
-      .replace (":p", Util.emoji ("😛"))
-      .replace (":-p", Util.emoji ("😛"))
-      .replace (":P", Util.emoji ("😛"))
-      .replace (":-P", Util.emoji ("😛"))
-      .replace ("8)", Util.emoji ("😎"))
-      .replace ("8-)", Util.emoji ("😎"));
-    */
-
     // Markdown.
     // Returns plaintext as fallback in case of parsing error.
     string message = escaped_text;

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -1,4 +1,30 @@
 namespace Util {
+  // TAGS to replace with EMOJIS, indexes MUST match.
+  public static const string[] TAGS = {
+    ":+1:", ":-1:", ":@", ">:(", ":$",
+    "<3", ":3", ":\\", ":'(", ":-'(",
+    ":o", ":O", ":(", ":-(", ":[",
+    ":-[", "xd", "xD", "Xd", "XD",
+    "0:)", "o:)", "O:)", ":)", ":-)",
+    ":]", ":-]", ":d", ":D", ":-D",
+    ":|", ":-|", ":p", ":P", ":-p",
+    ":-P", "8)", "8-)", "B:)", "B:-)",
+    ":tox:", ":lock:", ":ghost:", ":alien:", ":skull:",
+  };
+
+  // EMOJIS that replaces TAGS, indexes MUST match.
+  public static const string[] EMOJIS = {
+    "👍", "👎", "😠", "😠", "😊",
+    "💙", "🐱", "😕", "😢", "😢",
+    "😵", "😵", "😦", "😦", "😦",
+    "😦", "😆", "😆", "😆", "😆",
+    "😇", "😇", "😇", "😄", "😄",
+    "😄", "😄", "😆", "😆", "😆",
+    "😐", "😐", "😛", "😛", "😛",
+    "😛", "😎", "😎", "😎", "😎",
+    "🔒", "🔒", "👻", "👽", "💀",
+  };
+
   public static uint8[] hex2bin (string s) {
     uint8[] buf = new uint8[s.length / 2];
     for (int i = 0; i < buf.length; ++i) {
@@ -27,42 +53,60 @@ namespace Util {
     return result;
   }
 
+  public static string emojify (string emoji) {
+    return "<span face=\"EmojiOne\" foreground=\"#fcd226\">" + emoji + "</span>";
+  }
+
   public static string escape_html (string text) {
     return Markup.escape_text (text);
   }
 
+  public static string render_emojis (string text) {
+    string buffer = text;
+    for (int i = 0; i < Util.EMOJIS.length; i++) {
+      buffer = buffer.replace (Util.EMOJIS[i], Util.emojify (Util.EMOJIS[i]));
+      buffer = buffer.replace (Util.escape_html (Util.TAGS[i]), Util.emojify (Util.EMOJIS[i]));
+    }
+
+    return buffer;
+  }
+
   public static string render_litemd (string text) {
     string escaped_text = escape_html (text);
-    string emoji = escaped_text.replace (":+1:", "👍")
-                   .replace (":-1:", "👎")
-                   .replace (":@", "😠")
-                   .replace (">:(", "😠")
-                   .replace (":$", "😊")
-                   .replace ("<3", "💙")
-                   .replace (":3", "🐱")
-                   .replace (":\\", "😕")
-                   .replace (":'(", "😢")
-                   .replace (":-'(", "😢")
-                   .replace (":o", "😵")
-                   .replace (":O", "😵")
-                   .replace (":(", "😦")
-                   .replace (":-(", "😦")
-                   .replace (":-[", "😦")
-                   .replace (":[", "😦")
-                   .replace ("xD", "😆")
-                   .replace ("XD", "😆")
-                   .replace ("0:)", "😇")
-                   .replace (":)", "😄")
-                   .replace (":D", "😁")
-                   .replace (":-D", "😁")
-                   .replace (":|", "😐")
-                   .replace (":-|", "😐")
-                   .replace (":p", "😛")
-                   .replace (":-p", "😛")
-                   .replace (":P", "😛")
-                   .replace (":-P", "😛")
-                   .replace ("8)", "😎")
-                   .replace ("8-)", "😎");
+    string emojified = render_emojis (escaped_text);
+
+    /*string emoji = escaped_text
+      .replace (":+1:", Util.emoji ("👍"))
+      .replace (":-1:", Util.emoji ("👎"))
+      .replace (":@", Util.emoji ("😠"))
+      .replace (">:(", Util.emoji ("😠"))
+      .replace (":$", Util.emoji ("😊"))
+      .replace ("<3", Util.emoji ("💙"))
+      .replace (":3", Util.emoji ("🐱"))
+      .replace (":\\", Util.emoji ("😕"))
+      .replace (":'(", Util.emoji ("😢"))
+      .replace (":-'(", Util.emoji ("😢"))
+      .replace (":o", Util.emoji ("😵"))
+      .replace (":O", Util.emoji ("😵"))
+      .replace (":(", Util.emoji ("😦"))
+      .replace (":-(", Util.emoji ("😦"))
+      .replace (":-[", Util.emoji ("😦"))
+      .replace (":[", Util.emoji ("😦"))
+      .replace ("xD", Util.emoji ("😆"))
+      .replace ("XD", Util.emoji ("😆"))
+      .replace ("0:)", Util.emoji ("😇"))
+      .replace (":)", Util.emoji ("😄"))
+      .replace (":D", Util.emoji ("😁"))
+      .replace (":-D", Util.emoji ("😁"))
+      .replace (":|", Util.emoji ("😐"))
+      .replace (":-|", Util.emoji ("😐"))
+      .replace (":p", Util.emoji ("😛"))
+      .replace (":-p", Util.emoji ("😛"))
+      .replace (":P", Util.emoji ("😛"))
+      .replace (":-P", Util.emoji ("😛"))
+      .replace ("8)", Util.emoji ("😎"))
+      .replace ("8-)", Util.emoji ("😎"));
+    */
 
     // Markdown.
     // Returns plaintext as fallback in case of parsing error.
@@ -80,7 +124,7 @@ namespace Util {
         string matched_text = match_info.fetch (1);
         return @"<span face=\"monospace\" size=\"smaller\">$matched_text</span>";
       } else {
-        var uri = /(\w+:\S+)/.replace (emoji, -1, 0, "<a href=\"\\1\">\\1</a>");
+        var uri = /(\w+:\S+)/.replace (emojified, -1, 0, "<a href=\"\\1\">\\1</a>");
 
         var bold = /\B\*\*([^\*\*]{2,}?)\*\*\B/.replace (uri, -1, 0, "<b>\\1</b>");
         bold = /\B\*([^\*]{2,}?)\*\B/.replace (bold, -1, 0, "<b>\\1</b>");


### PR DESCRIPTION
- Replace the `.replace(tag, emoji)` hell with something "more" elegant.
- Add supports for `EmojiOne` font if installed on the computer.
- Make emojis Yellowish!

EmojiOne font can be found [here](https://github.com/Ranks/emojione/blob/master/assets/fonts/emojione-android.ttf?raw=true)
